### PR TITLE
Added tvOS as a supported platform.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let package = Package(
     name: "QGrid",
     platforms: [
       .iOS(.v13),
-      .macOS(.v10_15)
+      .macOS(.v10_15),
+      .tvOS(.v13)
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;✅ Xcode 11.0  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;✅ Swift 5+  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;✅ iOS 13+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;✅ tvOS 13+
 
 ## 🔷 Installation
 
@@ -124,7 +125,7 @@ Version `0.1.1` of `QGrid ` contains a very limited set of features. It could be
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Parameterize spacing&padding configuration depending on the device orientation  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add the option to specify scroll direction  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add content-only initializer to QGrid struct, without a collection of identified data as argument (As in SwiftUI’s `List`)  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add support for other platforms (tvOS, watchOS)  
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add support for other platforms (watchOS)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add `Stack` layout option (as in `UICollectionView`)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add unit/UI tests  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ ... many other improvements

--- a/Sources/QGrid/QGrid.swift
+++ b/Sources/QGrid/QGrid.swift
@@ -84,7 +84,11 @@ public struct QGrid<Data, Content>: View
   }
   
   private var cols: Int {
-    UIDevice.current.orientation.isLandscape ? columnsInLandscape : columns
+    #if os(tvOS)
+    return columnsInLandscape
+    #else
+    return UIDevice.current.orientation.isLandscape ? columnsInLandscape : columns
+    #endif
   }
   
   /// Declares the content and behavior of this view.


### PR DESCRIPTION
This pull request doesn't bring in any new features in support of tvOS, only the ability to use the existing functionality of QGrid, which seems to work just fine in tvOS as it does in iOS.

I've done some basic testing with loading and displaying several columns of data on screen, navigating the grid, and selecting cells in tvOS. All of which is working fine.