### PR TITLE
Fix macOS build issue

### DIFF
--- a/Sources/QGrid/QGrid.swift
+++ b/Sources/QGrid/QGrid.swift
@@ -86,6 +86,8 @@ public struct QGrid<Data, Content>: View
   private var cols: Int {
     #if os(tvOS)
     return columnsInLandscape
+    #elseif os(macOS)
+    return columnsInLandscape
     #else
     return UIDevice.current.orientation.isLandscape ? columnsInLandscape : columns
     #endif


### PR DESCRIPTION
QGrid was failing to build on macOS because `UIDevice` is not available. This change makes macOS behave the same as tvOS, in that it does not support rotation.