### PR TITLE
Add the option to specify scroll direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ struct PeopleView: View {
           vSpacing: 50,
           hSpacing: 20,
           vPadding: 100,
-          hPadding: 20) { person in
+          hPadding: 20,
+          scrollDirection: .horizontal) { person in
             GridCell(person: person)
     }
   }
@@ -130,7 +131,6 @@ struct PeopleView: View {
 Version `0.1.1` of `QGrid ` contains a very limited set of features. It could be extended by implementing the following tasks:
 
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Parameterize spacing&padding configuration depending on the device orientation  
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add the option to specify scroll direction  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add content-only initializer to QGrid struct, without a collection of identified data as argument (As in SwiftUI’s `List`)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add support for other platforms (watchOS)  
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;☘️ Add `Stack` layout option (as in `UICollectionView`)  

--- a/Sources/QGrid/QGrid.swift
+++ b/Sources/QGrid/QGrid.swift
@@ -41,6 +41,7 @@ public struct QGrid<Data, Content>: View
   private let hSpacing: CGFloat
   private let vPadding: CGFloat
   private let hPadding: CGFloat
+  private let scrollable: Bool
   
   private let data: [Data.Element]
   private let content: (Data.Element) -> Content
@@ -66,6 +67,7 @@ public struct QGrid<Data, Content>: View
               hSpacing: CGFloat = 10,
               vPadding: CGFloat = 10,
               hPadding: CGFloat = 10,
+              scrollable: Bool = true,
               content: @escaping (Data.Element) -> Content) {
     self.data = data.map { $0 }
     self.content = content
@@ -96,7 +98,7 @@ public struct QGrid<Data, Content>: View
   /// Declares the content and behavior of this view.
   public var body : some View {
     GeometryReader { geometry in
-      ScrollView(showsIndicators: false) {
+      ScrollView(axes, showsIndicators: false) {
         VStack(spacing: self.vSpacing) {
           ForEach((0..<self.rows).map { QGridIndex(id: $0) }) { row in
             self.rowAtIndex(row.id * self.cols,
@@ -136,6 +138,10 @@ public struct QGrid<Data, Content>: View
     let hSpacings = hSpacing * (CGFloat(self.cols) - 1)
     let width = geometry.size.width - hSpacings - hPadding * 2
     return width / CGFloat(self.cols)
+  }
+    
+  private var scrollAxes: Axis.Set {
+    return shouldScroll ? .vertical : []
   }
 }
 

--- a/Sources/QGrid/QGrid.swift
+++ b/Sources/QGrid/QGrid.swift
@@ -153,8 +153,6 @@ public struct QGrid<Data, Content>: View
         return [.vertical, .horizontal]
     case .none:
         return []
-    default:
-        return [.vertical]
     }
   }
 }

--- a/Sources/QGrid/QGrid.swift
+++ b/Sources/QGrid/QGrid.swift
@@ -32,6 +32,7 @@ import SwiftUI
 public struct QGrid<Data, Content>: View
   where Data : RandomAccessCollection, Content : View, Data.Element : Identifiable {
   private struct QGridIndex : Identifiable { var id: Int }
+  public enum ScrollDirection { case vertical, horizontal, both, none }
   
   // MARK: - STORED PROPERTIES
   
@@ -41,7 +42,7 @@ public struct QGrid<Data, Content>: View
   private let hSpacing: CGFloat
   private let vPadding: CGFloat
   private let hPadding: CGFloat
-  private let scrollable: Bool
+  private let scrollDirection: ScrollDirection
   
   private let data: [Data.Element]
   private let content: (Data.Element) -> Content
@@ -59,6 +60,7 @@ public struct QGrid<Data, Content>: View
   ///     - hSpacing: Horizontal spacing: The distance between each cell in grid's row. If not provided, the default value will be used.
   ///     - vPadding: Vertical padding: The distance between top/bottom edge of the grid and the parent view. If not provided, the default value will be used.
   ///     - hPadding: Horizontal padding: The distance between leading/trailing edge of the grid and the parent view. If not provided, the default value will be used.
+  ///         - scrollDirection: Scrolling direction: The direction of scrolling behaviour. If not provided, the default `.vertical` value will be used.
   ///     - content: A closure returning the content of the individual cell
   public init(_ data: Data,
               columns: Int,
@@ -67,7 +69,7 @@ public struct QGrid<Data, Content>: View
               hSpacing: CGFloat = 10,
               vPadding: CGFloat = 10,
               hPadding: CGFloat = 10,
-              scrollable: Bool = true,
+              scrollDirection: ScrollDirection = .vertical,
               content: @escaping (Data.Element) -> Content) {
     self.data = data.map { $0 }
     self.content = content
@@ -77,6 +79,7 @@ public struct QGrid<Data, Content>: View
     self.hSpacing = hSpacing
     self.vPadding = vPadding
     self.hPadding = hPadding
+    self.scrollDirection = scrollDirection
   }
   
   // MARK: - COMPUTED PROPERTIES
@@ -98,7 +101,7 @@ public struct QGrid<Data, Content>: View
   /// Declares the content and behavior of this view.
   public var body : some View {
     GeometryReader { geometry in
-      ScrollView(axes, showsIndicators: false) {
+      ScrollView(self.scrollAxes, showsIndicators: false) {
         VStack(spacing: self.vSpacing) {
           ForEach((0..<self.rows).map { QGridIndex(id: $0) }) { row in
             self.rowAtIndex(row.id * self.cols,
@@ -141,7 +144,18 @@ public struct QGrid<Data, Content>: View
   }
     
   private var scrollAxes: Axis.Set {
-    return shouldScroll ? .vertical : []
+    switch scrollDirection {
+    case .vertical:
+        return [.vertical]
+    case .horizontal:
+        return [.horizontal]
+    case .both:
+        return [.vertical, .horizontal]
+    case .none:
+        return []
+    default:
+        return [.vertical]
+    }
   }
 }
 


### PR DESCRIPTION
Added `scrollDirection` parameter which defines the direction of scrolling behaviour. 
If not provided, the vertical scrolling behaviour will be used.